### PR TITLE
[ENV][Chore] #1 : CI/CD를 위한 깃허브 엑션 설정

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,28 @@
+# PR 이벤트 발생 시(opened), 라벨이 붙는 이벤트 발생 시(labeled) 자동으로 팀원 중 Reviewer 2명 지정
+name: 'Auto Assign Reviewers'
+
+on:
+  pull_request:
+    types: [opened, labeled]
+
+jobs:
+  assign_reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check for label'
+        uses: actions/github-script@v6
+        id: label_check
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels;
+            return labels.some(label => label.name === '확인 요청');
+      - name: 'Assign Reviewers'
+        if: steps.label_check.outputs.result == 'true'
+        uses: kentaro-m/auto-assign-action@v1
+        with:
+          reviewers: |
+            effozen
+            happyhyep
+            juwon5272
+            leedongyull
+          number_of_reviewers: 2

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,59 @@
+# Reviewer 2명이 리뷰를 남기고 승인한 뒤, 라벨이 "작업 완료"로 변경되고 자동으로 특정 브랜치에 Merge하기
+name: 'Auto Merge Approved PRs'
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  auto_merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Get Pull Request'
+        id: pr
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const { data: pr } = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            return JSON.stringify(pr);
+      - name: 'Check Approvals and Labels'
+        id: check
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = JSON.parse(steps.pr.outputs.result);
+            const reviews = await github.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+            const approvals = reviews.data.filter(review => review.state === 'APPROVED');
+            const hasLabel = pr.labels.some(label => label.name === '확인 요청');
+            return approvals.length >= 2 && hasLabel;
+      - name: 'Change Label to 작업 완료'
+        if: steps.check.outputs.result == 'true'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: '작업 완료'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Remove Label 확인 요청'
+        if: steps.check.outputs.result == 'true'
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: '확인 요청'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Merge PR'
+        if: steps.check.outputs.result == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            await github.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI - Lint, Build, and Test with pnpm
+
+on:
+  pull_request:
+    branches:
+      - '*'  # 모든 브랜치에서 PR 생성 시 동작
+
+jobs:
+  lint-build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'  # 프로젝트에 맞는 Node.js 버전 지정
+
+      - name: Install pnpm
+        run: npm install -g pnpm  # pnpm 설치
+
+      - name: Install Dependencies
+        run: pnpm install  # pnpm을 사용하여 의존성 설치
+
+      - name: Run Linter
+        run: pnpm lint  # pnpm을 사용하여 린트 실행
+        continue-on-error: false # 린트 실패 시 워크플로우 실패로 처리
+
+      - name: Run Build
+        run: pnpm build  # pnpm을 사용하여 빌드 실행
+        continue-on-error: false # 빌드 실패 시 워크플로우 실패로 처리
+
+      - name: Run Tests
+        run: pnpm test  # pnpm을 사용하여 테스트 실행
+        continue-on-error: false # 테스트 실패 시 워크플로우 실패로 처리

--- a/.github/workflows/request-changes.yml
+++ b/.github/workflows/request-changes.yml
@@ -1,0 +1,43 @@
+#리뷰 과정에서 반려될 경우 라벨을 "수정 요청"으로 변경하고 작업자에게 알림 보내기
+name: 'Handle Requested Changes'
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  request_changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check if Changes Requested'
+        id: check
+        uses: actions/github-script@v6
+        with:
+          script: |
+            return context.payload.review.state === 'CHANGES_REQUESTED';
+      - name: 'Change Label to 수정 요청'
+        if: steps.check.outputs.result == 'true'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: '수정 요청'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Remove Label 확인 요청'
+        if: steps.check.outputs.result == 'true'
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: '확인 요청'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Notify Assignee via Comment'
+        if: steps.check.outputs.result == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const assignee = context.payload.pull_request.user.login;
+            const body = `@${assignee} 리뷰에서 수정 요청이 있습니다. 확인 부탁드립니다.`;
+            await github.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body,
+            });


### PR DESCRIPTION
- PR 생성시 리뷰어 2명 자동 설정 로직
- Reviewer 2명이 리뷰를 남기고 승인한 뒤, 라벨이 "작업 완료"로 변경되고 자동으로 특정 브랜치에 Merge하는 로직
- Lint, Build, Test 검사해서 오류가 있는지 확인 후 오류 발생 시 워크플로우 실패로 처리
- 리뷰 과정에서 반려될 경우 라벨을 "수정 요청"으로 변경하고 작업자에게 알림 보내기 로직