### PR TITLE
[FE][Feat] #107 : 네이버 지도 사용을 위한 로딩 코드 및 Type 추가

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,13 @@
   </head>
   <body>
     <div id="root"></div>
+	  <!--
+	    네이버 지도 API의 현재 옵션
+	    - ncpClientId: 네이버 클라우드 플랫폼에서 발급받은 Client ID
+	    - submodules: 사용할 서브모듈
+	    - callback: 콜백 함수
+	   -->
+	  <script type="text/javascript" src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=m5sz5l3xvw&submodules=geocoder&callback=CALLBACK_FUNCTION"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@storybook/react": "^8.4.2",
     "@storybook/react-vite": "^8.4.2",
     "@storybook/test": "^8.4.2",
+    "@types/navermaps": "^3.7.8",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react-swc": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       '@storybook/test':
         specifier: ^8.4.2
         version: 8.4.2(storybook@8.4.2(prettier@3.3.3))
+      '@types/navermaps':
+        specifier: ^3.7.8
+        version: 3.7.8
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.12
@@ -935,6 +938,9 @@ packages:
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
+  '@types/geojson@7946.0.14':
+    resolution: {integrity: sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==}
+
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
@@ -964,6 +970,9 @@ packages:
 
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+
+  '@types/navermaps@3.7.8':
+    resolution: {integrity: sha512-LzQffMWcUfhKzOuPpUONaXmMN6sAkNf92q1nycRplqorIl2oDjgdPftOw0LttTS0/k/YsotizawK+PtcRWbuog==}
 
   '@types/node@22.9.0':
     resolution: {integrity: sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==}
@@ -4062,6 +4071,8 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
+  '@types/geojson@7946.0.14': {}
+
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
@@ -4091,6 +4102,10 @@ snapshots:
   '@types/mdx@2.0.13': {}
 
   '@types/minimatch@5.1.2': {}
+
+  '@types/navermaps@3.7.8':
+    dependencies:
+      '@types/geojson': 7946.0.14
 
   '@types/node@22.9.0':
     dependencies:


### PR DESCRIPTION
## 📝 PR 개요

- `index.html` 에 네이버 지도 로딩을 위한 코드 추가
    - 비동기 통신
    - geocoder 모듈 추가 : 고유명칭을 갖고 좌표로 전환하는 모듈 추가
- TS 사용을 위한 Type 추가


## 🔍 변경 사항

- 타입 설정파일 추가 및 지도 로딩을 위한 코드 추가

## ✅ 체크리스트 (Checklist)

- [x] 로딩 코드가 제대로 작동하는가
- [x] 타입이 제대로 다운되었고, 설정되었는가 

## 🔄 관련 이슈 (Linked Issues)

#107 

## 📷 스크린샷 및 동영상 (선택 사항)


## 🧪 테스트 방법


## 📚 참고 자료 (선택 사항)

