### PR TITLE
[FE][FEAT] #134 : Layout Component 구현

### DIFF
--- a/frontend/src/component/Layout/Footer.tsx
+++ b/frontend/src/component/Layout/Footer.tsx
@@ -6,18 +6,18 @@ interface IFooterProps {
   active?: boolean;
 }
 
-export const Footer: React.FC<IFooterProps> = ({ title, onClick, active }) => {
-  const shadow = active ? 'shadow-float' : 'shadow-basic';
-  const fontColor = active ? 'text-gray-900' : 'text-gray-400';
+export const Footer: React.FC<IFooterProps> = (props: IFooterProps) => {
+  const shadow = props.active ? 'shadow-float' : 'shadow-basic';
+  const fontColor = props.active ? 'text-gray-900' : 'text-gray-400';
 
   return (
     <footer className="absolute bottom-5 w-[95%] h-[6%]">
       <button
         className={`w-full h-full bg-white text-black p-2 rounded-lg ${shadow} ${fontColor}`}
         type="button"
-        onClick={onClick}
+        onClick={props.onClick}
       >
-        {title}
+        {props.title}
       </button>
     </footer>
   );

--- a/frontend/src/component/Layout/Footer.tsx
+++ b/frontend/src/component/Layout/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { buttonActiveType } from './enumTypes';
 
 interface IFooterProps {
   title?: string;
@@ -7,13 +8,12 @@ interface IFooterProps {
 }
 
 export const Footer = (props: IFooterProps) => {
-  const shadow = props.active ? 'shadow-float' : 'shadow-basic';
-  const fontColor = props.active ? 'text-gray-900' : 'text-gray-400';
+  const buttonStyle = props.active ? buttonActiveType.ACTIVE : buttonActiveType.PASSIVE;
 
   return (
     <footer className="absolute bottom-5 w-[95%] h-[6%]">
       <button
-        className={`w-full h-full bg-white text-black p-2 rounded-lg ${shadow} ${fontColor}`}
+        className={`w-full h-full bg-white text-black p-2 rounded-lg ${buttonStyle}`}
         type="button"
         onClick={props.onClick}
       >

--- a/frontend/src/component/Layout/Footer.tsx
+++ b/frontend/src/component/Layout/Footer.tsx
@@ -6,7 +6,7 @@ interface IFooterProps {
   active?: boolean;
 }
 
-export const Footer: React.FC<IFooterProps> = (props: IFooterProps) => {
+export const Footer = (props: IFooterProps) => {
   const shadow = props.active ? 'shadow-float' : 'shadow-basic';
   const fontColor = props.active ? 'text-gray-900' : 'text-gray-400';
 

--- a/frontend/src/component/Layout/Footer.tsx
+++ b/frontend/src/component/Layout/Footer.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface IFooterProps {
+  title: string;
+  onClick?: () => void;
+  active?: boolean;
+}
+
+export const Footer: React.FC<IFooterProps> = ({ title, onClick, active }) => {
+  const shadow = active ? 'shadow-float' : 'shadow-basic';
+  const fontColor = active ? 'text-gray-900' : 'text-gray-100';
+
+  return (
+    <footer className="absolute bottom-5 w-[95%] h-[6%]">
+      <button
+        className={`w-full h-full bg-white text-black p-2 rounded-lg ${shadow} ${fontColor}`}
+        type="button"
+        onClick={onClick}
+      >
+        {title}
+      </button>
+    </footer>
+  );
+};

--- a/frontend/src/component/Layout/Footer.tsx
+++ b/frontend/src/component/Layout/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { buttonActiveType } from './enumTypes';
 
 interface IFooterProps {
@@ -13,7 +14,15 @@ export const Footer = (props: IFooterProps) => {
   return (
     <footer className="absolute bottom-5 w-[95%] h-[6%]">
       <button
-        className={`w-full h-full bg-white text-black p-2 rounded-lg ${buttonStyle}`}
+        className={classNames(
+          'w-full',
+          'h-full',
+          'bg-white',
+          'text-black',
+          'p-2',
+          'rounded-lg',
+          buttonStyle,
+        )}
         type="button"
         onClick={props.onClick}
       >

--- a/frontend/src/component/Layout/Footer.tsx
+++ b/frontend/src/component/Layout/Footer.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
 interface IFooterProps {
-  title: string;
+  title?: string;
   onClick?: () => void;
   active?: boolean;
 }
 
 export const Footer: React.FC<IFooterProps> = ({ title, onClick, active }) => {
   const shadow = active ? 'shadow-float' : 'shadow-basic';
-  const fontColor = active ? 'text-gray-900' : 'text-gray-100';
+  const fontColor = active ? 'text-gray-900' : 'text-gray-400';
 
   return (
     <footer className="absolute bottom-5 w-[95%] h-[6%]">

--- a/frontend/src/component/Layout/Header.tsx
+++ b/frontend/src/component/Layout/Header.tsx
@@ -6,13 +6,13 @@ interface IHeaderProps {
   buttonElement?: ReactNode;
 }
 
-export const Header: React.FC<IHeaderProps> = ({ title, isTransparency, buttonElement }) => {
-  const background = isTransparency ? '' : 'bg-white';
+export const Header: React.FC<IHeaderProps> = (props: IHeaderProps) => {
+  const background = props.isTransparency ? '' : 'bg-white';
 
   return (
     <header className={`w-full h-16 p-4 flex items-center ${background} text-black gap-[16px]`}>
-      {buttonElement}
-      <h1 className="text-base">{title}</h1>
+      {props.buttonElement}
+      <h1 className="text-base">{props.title}</h1>
     </header>
   );
 };

--- a/frontend/src/component/Layout/Header.tsx
+++ b/frontend/src/component/Layout/Header.tsx
@@ -1,0 +1,18 @@
+import React, { ReactNode } from 'react';
+
+interface IHeaderProps {
+  title?: string;
+  isTransparency?: boolean;
+  buttonElement?: ReactNode;
+}
+
+export const Header: React.FC<IHeaderProps> = ({ title, isTransparency, buttonElement }) => {
+  const background = isTransparency ? '' : 'bg-white';
+
+  return (
+    <header className={`w-full h-16 p-4 flex items-center ${background} text-black gap-[16px]`}>
+      {buttonElement}
+      <h1 className="text-base">{title}</h1>
+    </header>
+  );
+};

--- a/frontend/src/component/Layout/Header.tsx
+++ b/frontend/src/component/Layout/Header.tsx
@@ -6,7 +6,7 @@ interface IHeaderProps {
   buttonElement?: ReactNode;
 }
 
-export const Header: React.FC<IHeaderProps> = (props: IHeaderProps) => {
+export const Header = (props: IHeaderProps) => {
   const background = props.isTransparency ? '' : 'bg-white';
 
   return (

--- a/frontend/src/component/Layout/Header.tsx
+++ b/frontend/src/component/Layout/Header.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import { backgroundType } from './enumTypes';
 
 interface IHeaderProps {
   title?: string;
@@ -7,7 +8,7 @@ interface IHeaderProps {
 }
 
 export const Header = (props: IHeaderProps) => {
-  const background = props.isTransparency ? '' : 'bg-white';
+  const background = props.isTransparency ? backgroundType.TRANSPARENCY : backgroundType.WHITE;
 
   return (
     <header className={`w-full h-16 p-4 flex items-center ${background} text-black gap-[16px]`}>

--- a/frontend/src/component/Layout/Header.tsx
+++ b/frontend/src/component/Layout/Header.tsx
@@ -1,9 +1,9 @@
-import React, { ReactNode } from 'react';
+import React, { ReactElement } from 'react';
 
 interface IHeaderProps {
   title?: string;
   isTransparency?: boolean;
-  buttonElement?: ReactNode;
+  buttonElement?: ReactElement;
 }
 
 export const Header = (props: IHeaderProps) => {

--- a/frontend/src/component/Layout/Header.tsx
+++ b/frontend/src/component/Layout/Header.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import classNames from 'classnames';
 import { backgroundType } from './enumTypes';
 
 interface IHeaderProps {
@@ -11,7 +12,18 @@ export const Header = (props: IHeaderProps) => {
   const background = props.isTransparency ? backgroundType.TRANSPARENCY : backgroundType.WHITE;
 
   return (
-    <header className={`w-full h-16 p-4 flex items-center ${background} text-black gap-[16px]`}>
+    <header
+      className={classNames(
+        'w-full',
+        'h-16',
+        'p-4',
+        'flex ',
+        'items-center ',
+        'text-black ',
+        'gap-[16px]',
+        background,
+      )}
+    >
       {props.buttonElement}
       <h1 className="text-base">{props.title}</h1>
     </header>

--- a/frontend/src/component/Layout/Layout.tsx
+++ b/frontend/src/component/Layout/Layout.tsx
@@ -1,0 +1,34 @@
+import React, { ReactNode } from 'react';
+import { Header } from './Header';
+import { Footer } from './Footer';
+
+interface ILayoutProps {
+  children: ReactNode;
+  headerTitle?: string;
+  footerTitle?: string;
+  isHeaderTransparent?: boolean;
+  footerActive?: boolean;
+  headerButton?: ReactNode;
+  footerOnClick?: () => void;
+}
+
+export const Layout: React.FC<ILayoutProps> = ({
+  children,
+  headerTitle = '사용자 1에 대한 경로 설정',
+  footerTitle = '출발지점 선택',
+  isHeaderTransparent = false,
+  footerActive = true,
+  headerButton,
+  footerOnClick,
+}) => (
+  <div className="flex flex-col items-center w-full h-full">
+    {/* Header */}
+    <Header title={headerTitle} isTransparency={isHeaderTransparent} buttonElement={headerButton} />
+
+    {/* Main content */}
+    <main>{children}</main>
+
+    {/* Footer */}
+    <Footer title={footerTitle} onClick={footerOnClick} active={footerActive} />
+  </div>
+);

--- a/frontend/src/component/Layout/Layout.tsx
+++ b/frontend/src/component/Layout/Layout.tsx
@@ -12,23 +12,19 @@ interface ILayoutProps {
   footerOnClick?: () => void;
 }
 
-export const Layout: React.FC<ILayoutProps> = ({
-  children,
-  headerTitle,
-  footerTitle,
-  isHeaderTransparent = false,
-  footerActive = true,
-  headerButton,
-  footerOnClick,
-}) => (
+export const Layout: React.FC<ILayoutProps> = (props: ILayoutProps) => (
   <div className="flex flex-col items-center w-full h-full bg-gray-400">
     {/* Header */}
-    <Header title={headerTitle} isTransparency={isHeaderTransparent} buttonElement={headerButton} />
+    <Header
+      title={props.headerTitle}
+      isTransparency={props.isHeaderTransparent}
+      buttonElement={props.headerButton}
+    />
 
     {/* Main content */}
-    <main>{children}</main>
+    <main>{props.children}</main>
 
     {/* Footer */}
-    <Footer title={footerTitle} onClick={footerOnClick} active={footerActive} />
+    <Footer title={props.footerTitle} onClick={props.footerOnClick} active={props.footerActive} />
   </div>
 );

--- a/frontend/src/component/Layout/Layout.tsx
+++ b/frontend/src/component/Layout/Layout.tsx
@@ -12,7 +12,7 @@ interface ILayoutProps {
   footerOnClick?: () => void;
 }
 
-export const Layout: React.FC<ILayoutProps> = (props: ILayoutProps) => (
+export const Layout = (props: ILayoutProps) => (
   <div className="flex flex-col items-center w-full h-full bg-gray-400">
     {/* Header */}
     <Header

--- a/frontend/src/component/Layout/Layout.tsx
+++ b/frontend/src/component/Layout/Layout.tsx
@@ -9,7 +9,7 @@ interface ILayoutProps {
   isHeaderTransparent?: boolean;
   footerActive?: boolean;
   headerButton?: ReactElement;
-  footerOnClick?: () => void;
+  handleFooterClick?: () => void;
 }
 
 export const Layout = (props: ILayoutProps) => (
@@ -25,6 +25,10 @@ export const Layout = (props: ILayoutProps) => (
     <main>{props.children}</main>
 
     {/* Footer */}
-    <Footer title={props.footerTitle} onClick={props.footerOnClick} active={props.footerActive} />
+    <Footer
+      title={props.footerTitle}
+      onClick={props.handleFooterClick}
+      active={props.footerActive}
+    />
   </div>
 );

--- a/frontend/src/component/Layout/Layout.tsx
+++ b/frontend/src/component/Layout/Layout.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import classNames from 'classnames';
 import { Header } from './Header';
 import { Footer } from './Footer';
 
@@ -13,7 +14,9 @@ interface ILayoutProps {
 }
 
 export const Layout = (props: ILayoutProps) => (
-  <div className="flex flex-col items-center w-full h-full bg-gray-400">
+  <div
+    className={classNames('flex', 'flex-col', 'items-center', 'w-full', 'h-full', 'bg-gray-400')}
+  >
     {/* Header */}
     <Header
       title={props.headerTitle}

--- a/frontend/src/component/Layout/Layout.tsx
+++ b/frontend/src/component/Layout/Layout.tsx
@@ -1,14 +1,14 @@
-import React, { ReactNode } from 'react';
+import React, { ReactElement } from 'react';
 import { Header } from './Header';
 import { Footer } from './Footer';
 
 interface ILayoutProps {
-  children: ReactNode;
+  children: ReactElement;
   headerTitle?: string;
   footerTitle?: string;
   isHeaderTransparent?: boolean;
   footerActive?: boolean;
-  headerButton?: ReactNode;
+  headerButton?: ReactElement;
   footerOnClick?: () => void;
 }
 

--- a/frontend/src/component/Layout/Layout.tsx
+++ b/frontend/src/component/Layout/Layout.tsx
@@ -14,14 +14,14 @@ interface ILayoutProps {
 
 export const Layout: React.FC<ILayoutProps> = ({
   children,
-  headerTitle = '사용자 1에 대한 경로 설정',
-  footerTitle = '출발지점 선택',
+  headerTitle,
+  footerTitle,
   isHeaderTransparent = false,
   footerActive = true,
   headerButton,
   footerOnClick,
 }) => (
-  <div className="flex flex-col items-center w-full h-full">
+  <div className="flex flex-col items-center w-full h-full bg-gray-400">
     {/* Header */}
     <Header title={headerTitle} isTransparency={isHeaderTransparent} buttonElement={headerButton} />
 

--- a/frontend/src/component/Layout/enumTypes.ts
+++ b/frontend/src/component/Layout/enumTypes.ts
@@ -1,0 +1,9 @@
+export enum buttonActiveType {
+  'ACTIVE' = 'shadow-float text-gray-900',
+  'PASSIVE' = 'shadow-basic text-gray-400',
+}
+
+export enum backgroundType {
+  'TRANSPARENCY' = '',
+  'WHITE' = 'bg-white',
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,7 +10,7 @@ module.exports = {
         grayscale: {
           white: '#FFFFFF',
           50: 'rgba(60, 60, 67, 0.36)',
-          100: '#EDF2F7',
+          100: '#B7B7B7',
           200: '#6D6D6D',
           400: '#555555',
           800: '#3E3E3E',
@@ -42,6 +42,10 @@ module.exports = {
         '4xl': '2.25rem',
         '5xl': '3rem',
         '6xl': '4rem',
+      },
+      boxShadow: {
+        float: '0 4px 20px rgba(0, 0, 0, 0.13)',
+        basic: 'inset 0 0 3px rgba(0, 0, 0, 0.11)',
       },
     }, // 필요한 커스터마이징을 여기서 설정 가능
   },


### PR DESCRIPTION
---

## 📝 PR 개요

- header, footer로 이루어진 layout component 구현
- 확장성과 보편성을 위해 props로 설정
- tailwind boxshadow 추가

---

## ✅ 체크리스트 (Checklist)

- [x] header 구현
- [x] footer 구현

---

## 🔄 관련 이슈 (Linked Issues)

```
import React, { ReactNode } from 'react';
import { Header } from './Header';
import { Footer } from './Footer';

interface ILayoutProps {
  children: ReactNode;
  headerTitle?: string;
  footerTitle?: string;
  isHeaderTransparent?: boolean;
  footerActive?: boolean;
  headerButton?: ReactNode;
  footerOnClick?: () => void;
}

export const Layout: React.FC<ILayoutProps> = ({
  children,
  headerTitle,
  footerTitle,
  isHeaderTransparent = false,
  footerActive = true,
  headerButton,
  footerOnClick,
}) => (
  <div className="flex flex-col items-center w-full h-full bg-gray-400">
    {/* Header */}
    <Header title={headerTitle} isTransparency={isHeaderTransparent} buttonElement={headerButton} />

    {/* Main content */}
    <main>{children}</main>

    {/* Footer */}
    <Footer title={footerTitle} onClick={footerOnClick} active={footerActive} />
  </div>
);

```
기본 Layout의 틀은 위와 같고 현재 피그마의 모든 header, footer 대응 가능

하지만, Router에서 사용 시 페이지 마다 달라지는 props들이 있기에

```
      <Route
        path="/add-channel"
        element={
          <Layout headerTitle="경로 방 추가" footerTitle="추가하기">
            <AddChannel />
          </Layout>
        }
      />

      <Route
        path="/add-channel/:user"
        element={
          <Layout headerTitle="사용자 경로 설정" footerTitle="다음 단계" isHeaderTransparent>
            <UserRoute />
          </Layout>
        }
      />

```
이러한 형식으로 코드가 길어지고 각각 모두 설정해줘야 합니다.

이러한 방식이 맞는건지 모르겠습니다! 리뷰 부탁 드립니당


## 📷 스크린샷 및 동영상 (선택 사항)
- 우선 공통 버튼 컴포넌트가 없어 좌측 상단 토스트바, 뒤로가기 버튼은 없는 상태  

- 상단 제목 X
![noTitle](https://github.com/user-attachments/assets/5d000b96-a43a-475c-8836-0066e9ac0ecd)
- 상단 제목 O 하단 버튼 active 상태
![하단 active false](https://github.com/user-attachments/assets/f84c7692-a44b-49f9-92fa-e3feaf86c871)
- header 투명 가능
![header 투명 간으](https://github.com/user-attachments/assets/e59fd4ac-3682-4bf3-a0e3-b594917d9f25)


---

**설명**: UI 변경 사항이 포함된 경우, 변경된 화면을 시각적으로 보여주기 위해 스크린샷이나 동영상을 첨부하면 도움이 됩니다. 리뷰어는 화면 변경 사항을 바로 확인할 수 있어 코드 리뷰가 더 효과적입니다.

---

🔄 피드백 반영 및 수정
- props 전달 방식 수정
- React.FC 제거
- ReactNode 대신 ReactElement를 이용해 구체화
