### PR TITLE
[FE][Feat] #30 : Main 페이지

### DIFF
--- a/frontend/src/hooks/getUserLocation.ts
+++ b/frontend/src/hooks/getUserLocation.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+
+interface IGetUserLocation {
+  lat: number | null;
+  lng: number | null;
+  error: string | null;
+}
+
+/**
+ * 사용자 위치를 가져오는 커스텀 Hook입니다.
+ *
+ * @returns {IGetUserLocation} 사용자 위치 (위도, 경도)와 에러 메시지를 포함한 객체를 반환합니다.
+ *
+ * @remarks
+ * - Geolocation API를 사용하여 사용자의 현재 위치를 가져옵니다.
+ * - 위치를 성공적으로 가져오지 못하면 기본 위치 네이버 1784 (37.3595704, 127.105399)로 설정됩니다.
+ * - Geolocation API가 지원되지 않는 경우에도 기본 위치로 설정됩니다.
+ *
+ * @example
+ * ```tsx
+ * const { lat, lng, error } = getUserLocation();
+ *
+ * if (error) {
+ *   console.error('위치 가져오기 에러:', error);
+ * } else {
+ *   console.log('현재 위치:', lat, lng);
+ * }
+ * ```
+ */
+
+export const getUserLocation = (): IGetUserLocation => {
+  const [location, setLocation] = useState<IGetUserLocation>({
+    lat: null,
+    lng: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        position => {
+          setLocation({
+            lat: position.coords.latitude,
+            lng: position.coords.longitude,
+            error: null,
+          });
+        },
+        error => {
+          setLocation({
+            lat: 37.3595704,
+            lng: 127.105399,
+            error: error.message,
+          });
+        },
+      );
+    } else {
+      setLocation({
+        lat: 37.3595704,
+        lng: 127.105399,
+        error: '현재 위치를 불러오지 못했습니다',
+      });
+    }
+  }, []);
+
+  return location;
+};

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,1 +1,70 @@
-export const Main = () => <>Hello</>;
+import React, { Fragment } from 'react';
+import { getUserLocation } from '@/hooks/getUserLocation';
+import { Map } from '@/component/maps/Map';
+import { BottomSheet } from '@/component/bottomsheet/BottomSheet';
+import { Content } from '@/component/content/Content';
+import { MdFormatListBulleted } from 'react-icons/md';
+
+const contentData = [
+  {
+    id: '1',
+    title: '아들네 집으로',
+    time: '0시간 34분',
+    person: 2,
+    link: '/test1',
+  },
+  {
+    id: '2',
+    title: '손자네 집으로',
+    time: '2시간 32분',
+    person: 0,
+    link: '/test2',
+  },
+  {
+    id: '3',
+    title: '마을회관으로',
+    time: '0시간 12분',
+    person: 1,
+    link: '/test3',
+  },
+];
+
+export const Main = () => {
+  const { lat, lng, error } = getUserLocation();
+  const MIN_HEIGHT = 0.5;
+  const MAX_HEIGHT = 0.8;
+
+  return (
+    <div className="flex h-screen flex-col">
+      <header className="absolute left-0 right-0 top-0 z-10 flex p-4">
+        <button type="button" className="text-gray-700">
+          <MdFormatListBulleted size={24} />
+        </button>
+      </header>
+
+      <main
+        className="relative flex-grow"
+        style={{
+          height: `calc(100% - ${MIN_HEIGHT * 100}%)`,
+        }}
+      >
+        {lat && lng ? (
+          <Map lat={lat} lng={lng} type="naver" />
+        ) : (
+          <section className="flex h-full items-center justify-center">
+            {error ? `Error: ${error}` : 'Loading'}
+          </section>
+        )}
+      </main>
+
+      <BottomSheet minHeight={MIN_HEIGHT} maxHeight={MAX_HEIGHT}>
+        {contentData.map(item => (
+          <Fragment key={item.id}>
+            <Content title={item.title} time={item.time} person={item.person} link={item.link} />
+            <hr className="my-2" />
+          </Fragment>
+        ))}
+      </BottomSheet>
+    </div>
+  );
+};


### PR DESCRIPTION
## 📝 PR 개요

- 현재 위치를 받아오는 함수 구현
  - 현재의 위치를 반환
  - 현재의 위치를 반환할 수 없다면 error와 함께 네이버의 위치로 반환
  
- 메인 페이지 구현
  - 지도에 현재 위치를 기준으로 표시
  - 바텀시트

## ✅ 체크리스트 (Checklist)

- [x] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [x] 스타일 가이드와 일관성을 유지했는지 확인
- [x] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인

## 🔄 관련 이슈 (Linked Issues)

- contentData 더미데이터를 추후 분리하거나 백엔드와의 연결로 대체할 예정입니다

## 📷 스크린샷 및 동영상 

<img width="340" alt="image" src="https://github.com/user-attachments/assets/6fe7559d-c9b7-426c-aaba-9f031f1808fb">
