### PR TITLE
[ENV][Fix] #1 : auto-assign 라벨 바뀔때마다 되는 문제 수정

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -2,7 +2,7 @@ name: 'Auto Assign Reviewers'
 
 on:
   pull_request:
-    types: [opened, labeled]
+    types: [opened]
 
 jobs:
   assign_reviewers:
@@ -44,7 +44,7 @@ jobs:
           script: |
             const targetBranch = context.payload.pull_request.base.ref;
             const reviewers = (targetBranch === 'main' || targetBranch === 'development') ? 3 : 2;
-            core.setOutput('number_of_reviewers', reviewers);
+            return { number_of_reviewers: reviewers };
 
       - name: 'Assign Reviewers'
         uses: kentaro-m/auto-assign-action@v2.0.0
@@ -52,3 +52,4 @@ jobs:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: '.github/auto_assign_config.yml'
           numberOfReviewers: ${{ steps.determine_reviewers.outputs.number_of_reviewers }}
+

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           script: |
             const targetBranch = context.payload.pull_request.base.ref;
-            const reviewers = targetBranch === 'main' ? 3 : 2;
+            const reviewers = (targetBranch === 'main' || targetBranch === 'development') ? 3 : 2;
             core.setOutput('number_of_reviewers', reviewers);
 
       - name: 'Assign Reviewers'


### PR DESCRIPTION
## 📝 PR 개요

github action 중 auto assign 버그를 수정하였습니다.

## 🔍 변경 사항

- 이벤트 동작을 opened 인 경우만 처리하도록 했습니다.

```
on:
  pull_request:
    types: [opened]

```

- 메인 브렌치인지와 dev 브렌치인 경우 리뷰어가 3명이 할당되도록 수정하였습니다.

```
      - name: 'Determine Number of Reviewers'
        id: determine_reviewers
        uses: actions/github-script@v6
        with:
          script: |
            const targetBranch = context.payload.pull_request.base.ref;
            const reviewers = targetBranch === 'main' ? 3 : 2;
            return { number_of_reviewers: reviewers };

      - name: 'Assign Reviewers'
        uses: kentaro-m/auto-assign-action@v2.0.0
        with:
          repo-token: '${{ secrets.GITHUB_TOKEN }}'
          configuration-path: '.github/auto_assign_config.yml'
          numberOfReviewers: ${{ steps.determine_reviewers.outputs.number_of_reviewers }}


```
