### PR TITLE
[FE][Feat] #4 : 캔버스에 선그리기, 이동, 확대/축소 훅

### DIFF
--- a/frontend/src/component/linedrawer/Linedrawer.tsx
+++ b/frontend/src/component/linedrawer/Linedrawer.tsx
@@ -1,86 +1,57 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState } from 'react';
+import { useDrawing } from '@/hooks/useDrawing';
+import { usePanning } from '@/hooks/usePanning';
+import { useZoom } from '@/hooks/useZoom';
 
 interface IPoint {
   x: number;
   y: number;
 }
 
-interface ILinedrawerProps {
-  width?: number | string;
-  height?: number | string;
-}
+const NAVER_STEP_SCALES = [
+  100, 50, 30, 20, 10, 5, 3, 1, 0.5, 0.3, 0.1, 0.05, 0.03, 0.02, 0.01, 0.005,
+];
+const LINE_WIDTH = 2;
+const STROKE_STYLE = 'black';
 
-export const Linedrawer: React.FC<ILinedrawerProps> = () => {
+export const Linedrawer = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [points, setPoints] = useState<IPoint[]>([]);
-  const [previewPoint, setPreviewPoint] = useState<IPoint | null>(null);
 
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
+  const { draw, scaleRef, viewPosRef } = useDrawing({
+    canvasRef,
+    points,
+    lineWidth: LINE_WIDTH,
+    strokeStyle: STROKE_STYLE,
+  });
+  const { handleMouseMove, handleMouseDown, handleMouseUp } = usePanning({ viewPosRef, draw });
+  const { handleWheel } = useZoom({
+    scaleRef,
+    viewPosRef,
+    draw,
+    stepScales: NAVER_STEP_SCALES,
+  });
 
-    const context = canvas.getContext('2d');
-    if (!context) return;
+  const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
 
-    context.clearRect(0, 0, canvas.width, canvas.height);
-    context.lineWidth = 2;
-    context.strokeStyle = 'black';
-
-    if (points.length > 1) {
-      context.beginPath();
-      context.moveTo(points[0].x, points[0].y);
-      for (let i = 1; i < points.length; i += 1) {
-        context.lineTo(points[i].x, points[i].y);
-      }
-      context.stroke();
-    }
-
-    if (points.length > 0 && previewPoint) {
-      context.beginPath();
-      context.moveTo(points[points.length - 1].x, points[points.length - 1].y);
-      context.lineTo(previewPoint.x, previewPoint.y);
-      context.strokeStyle = 'rgba(0, 0, 0, 0.5)';
-      context.stroke();
-    }
-  }, [points, previewPoint]);
-
-  const handleCanvasClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    const rect = canvas.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
-    const newPoint = { x, y };
-
-    setPoints([...points, newPoint]);
-  };
-
-  const handleMouseMove = (event: React.MouseEvent<HTMLCanvasElement>) => {
-    if (points.length === 0) return;
-
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    const rect = canvas.getBoundingClientRect();
-    const x = event.clientX - rect.left;
-    const y = event.clientY - rect.top;
-    setPreviewPoint({ x, y });
+    const x = (e.clientX - rect.left - viewPosRef.current.x) / scaleRef.current;
+    const y = (e.clientY - rect.top - viewPosRef.current.y) / scaleRef.current;
+    setPoints(prevPoints => [...prevPoints, { x, y }]);
   };
 
   return (
-    <div className="z-11 absolute">
-      <canvas
-        ref={canvasRef}
-        // TODO : canvas의 넓이 높이 지도에 맞게 조절
-        width={typeof width === 'number' ? width : '430'}
-        height={typeof height === 'number' ? height : '862'}
-        onClick={handleCanvasClick}
-        onMouseMove={handleMouseMove}
-        className="border border-gray-300"
-        style={{ backgroundColor: 'transparent' }}
-        data-testid="canvas"
-      />
-    </div>
+    <canvas
+      ref={canvasRef}
+      width="800"
+      height="600"
+      style={{ border: '1px solid', cursor: 'crosshair' }}
+      onClick={handleCanvasClick}
+      onMouseMove={handleMouseMove}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+      onWheel={handleWheel}
+    />
   );
 };

--- a/frontend/src/component/linedrawer/Linedrawer.tsx
+++ b/frontend/src/component/linedrawer/Linedrawer.tsx
@@ -1,12 +1,9 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { useDrawing } from '@/hooks/useDrawing';
 import { usePanning } from '@/hooks/usePanning';
 import { useZoom } from '@/hooks/useZoom';
-
-interface IPoint {
-  x: number;
-  y: number;
-}
+import { MdArrowCircleLeft, MdArrowCircleRight } from 'react-icons/md';
+import { useUndoRedo } from '@/hooks/useUndoRedo';
 
 const NAVER_STEP_SCALES = [
   100, 50, 30, 20, 10, 5, 3, 1, 0.5, 0.3, 0.1, 0.05, 0.03, 0.02, 0.01, 0.005,
@@ -16,7 +13,7 @@ const STROKE_STYLE = 'black';
 
 export const Linedrawer = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [points, setPoints] = useState<IPoint[]>([]);
+  const { points, addPoint, undo, redo, undoStack, redoStack } = useUndoRedo([]);
 
   const { draw, scaleRef, viewPosRef } = useDrawing({
     canvasRef,
@@ -38,20 +35,44 @@ export const Linedrawer = () => {
 
     const x = (e.clientX - rect.left - viewPosRef.current.x) / scaleRef.current;
     const y = (e.clientY - rect.top - viewPosRef.current.y) / scaleRef.current;
-    setPoints(prevPoints => [...prevPoints, { x, y }]);
+    addPoint({ x, y });
   };
 
   return (
-    <canvas
-      ref={canvasRef}
-      width="800"
-      height="600"
-      style={{ border: '1px solid', cursor: 'crosshair' }}
-      onClick={handleCanvasClick}
-      onMouseMove={handleMouseMove}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
-      onWheel={handleWheel}
-    />
+    <div className="relative h-[600px] w-[800px]">
+      <div className="absolute left-1/2 top-[10px] z-10 flex -translate-x-1/2 transform gap-2">
+        <button
+          type="button"
+          onClick={undo}
+          disabled={undoStack.length === 0}
+          className={`h-[35px] w-[35px] ${
+            undoStack.length === 0 ? 'cursor-not-allowed opacity-50' : ''
+          }`}
+        >
+          <MdArrowCircleLeft size={24} />
+        </button>
+        <button
+          type="button"
+          onClick={redo}
+          disabled={redoStack.length === 0}
+          className={`h-[35px] w-[35px] ${
+            redoStack.length === 0 ? 'cursor-not-allowed opacity-50' : ''
+          }`}
+        >
+          <MdArrowCircleRight size={24} />
+        </button>
+      </div>
+      <canvas
+        ref={canvasRef}
+        width="800"
+        height="600"
+        className="cursor-crosshair border border-gray-300"
+        onClick={handleCanvasClick}
+        onMouseMove={handleMouseMove}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onWheel={handleWheel}
+      />
+    </div>
   );
 };

--- a/frontend/src/component/linedrawer/Linedrawer.tsx
+++ b/frontend/src/component/linedrawer/Linedrawer.tsx
@@ -5,11 +5,16 @@ import { useZoom } from '@/hooks/useZoom';
 import { MdArrowCircleLeft, MdArrowCircleRight } from 'react-icons/md';
 import { useUndoRedo } from '@/hooks/useUndoRedo';
 
+// 네이버지도 기준 확대/축소 비율 단계
 const NAVER_STEP_SCALES = [
   100, 50, 30, 20, 10, 5, 3, 1, 0.5, 0.3, 0.1, 0.05, 0.03, 0.02, 0.01, 0.005,
 ];
+// 선의 굵기 상수
 const LINE_WIDTH = 2;
+// 선의 색 상수
 const STROKE_STYLE = 'black';
+// 지도의 처음 확대/축소 비율 단계 index
+const INITIAL_ZOOM_INDEX = 7;
 
 export const Linedrawer = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -20,6 +25,7 @@ export const Linedrawer = () => {
     points,
     lineWidth: LINE_WIDTH,
     strokeStyle: STROKE_STYLE,
+    initialScale: NAVER_STEP_SCALES[INITIAL_ZOOM_INDEX],
   });
   const { handleMouseMove, handleMouseDown, handleMouseUp } = usePanning({ viewPosRef, draw });
   const { handleWheel } = useZoom({
@@ -27,6 +33,7 @@ export const Linedrawer = () => {
     viewPosRef,
     draw,
     stepScales: NAVER_STEP_SCALES,
+    initialZoomIndex: INITIAL_ZOOM_INDEX,
   });
 
   const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {

--- a/frontend/src/hooks/useDrawing.ts
+++ b/frontend/src/hooks/useDrawing.ts
@@ -1,0 +1,61 @@
+import { useRef, useEffect } from 'react';
+
+interface IPoint {
+  x: number;
+  y: number;
+}
+
+interface IUseDrawingProps {
+  canvasRef: React.RefObject<HTMLCanvasElement>;
+  points: IPoint[];
+  lineWidth: number;
+  strokeStyle: string;
+}
+
+const INITIAL_POSITION = { x: 0, y: 0 };
+const STEP_SCALES = [100, 50, 30, 20, 10, 5, 3, 1, 0.5, 0.3, 0.1, 0.05, 0.03, 0.02, 0.01, 0.005];
+
+export const useDrawing = (props: IUseDrawingProps) => {
+  const scaleRef = useRef(STEP_SCALES[7]);
+  const viewPosRef = useRef(INITIAL_POSITION);
+
+  const getCanvasContext = (): CanvasRenderingContext2D | null =>
+    props.canvasRef.current?.getContext('2d') || null;
+
+  const setTransform = (context: CanvasRenderingContext2D) => {
+    context.setTransform(
+      scaleRef.current,
+      0,
+      0,
+      scaleRef.current,
+      viewPosRef.current.x,
+      viewPosRef.current.y,
+    );
+  };
+
+  const draw = () => {
+    const context = getCanvasContext();
+    if (!context) return;
+
+    const canvas = props.canvasRef.current;
+    if (!canvas) return;
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    setTransform(context);
+
+    if (props.points.length > 1) {
+      context.lineWidth = props.lineWidth / scaleRef.current;
+      context.strokeStyle = props.strokeStyle;
+      context.beginPath();
+      context.moveTo(props.points[0].x, props.points[0].y);
+      props.points.slice(1).forEach(point => context.lineTo(point.x, point.y));
+      context.stroke();
+    }
+  };
+
+  useEffect(() => {
+    draw();
+  }, [props.points]);
+
+  return { draw, scaleRef, viewPosRef };
+};

--- a/frontend/src/hooks/useDrawing.ts
+++ b/frontend/src/hooks/useDrawing.ts
@@ -50,6 +50,17 @@ export const useDrawing = (props: IUseDrawingProps) => {
       context.moveTo(props.points[0].x, props.points[0].y);
       props.points.slice(1).forEach(point => context.lineTo(point.x, point.y));
       context.stroke();
+    } else if (props.points.length === 1) {
+      context.fillStyle = props.strokeStyle;
+      context.beginPath();
+      context.arc(
+        props.points[0].x,
+        props.points[0].y,
+        (props.lineWidth + 1) / scaleRef.current,
+        0,
+        2 * Math.PI,
+      );
+      context.fill();
     }
   };
 

--- a/frontend/src/hooks/useDrawing.ts
+++ b/frontend/src/hooks/useDrawing.ts
@@ -10,13 +10,13 @@ interface IUseDrawingProps {
   points: IPoint[];
   lineWidth: number;
   strokeStyle: string;
+  initialScale: number;
 }
 
 const INITIAL_POSITION = { x: 0, y: 0 };
-const STEP_SCALES = [100, 50, 30, 20, 10, 5, 3, 1, 0.5, 0.3, 0.1, 0.05, 0.03, 0.02, 0.01, 0.005];
 
 export const useDrawing = (props: IUseDrawingProps) => {
-  const scaleRef = useRef(STEP_SCALES[7]);
+  const scaleRef = useRef(props.initialScale);
   const viewPosRef = useRef(INITIAL_POSITION);
 
   const getCanvasContext = (): CanvasRenderingContext2D | null =>

--- a/frontend/src/hooks/usePanning.ts
+++ b/frontend/src/hooks/usePanning.ts
@@ -1,0 +1,42 @@
+import { useRef } from 'react';
+
+interface IUsePanningProps {
+  viewPosRef: React.MutableRefObject<{ x: number; y: number }>;
+  draw: () => void;
+}
+
+const INITIAL_POSITION = { x: 0, y: 0 };
+
+export const usePanning = (props: IUsePanningProps) => {
+  const panningRef = useRef(false);
+  const startPosRef = useRef(INITIAL_POSITION);
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!panningRef.current || !props.viewPosRef.current) return;
+
+    const viewPos = props.viewPosRef.current;
+    const { x, y } = startPosRef.current;
+
+    viewPos.x = e.clientX - x;
+    viewPos.y = e.clientY - y;
+
+    props.draw();
+  };
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!props.viewPosRef.current) return;
+
+    const viewPos = props.viewPosRef.current;
+    startPosRef.current = {
+      x: e.clientX - viewPos.x,
+      y: e.clientY - viewPos.y,
+    };
+    panningRef.current = true;
+  };
+
+  const handleMouseUp = () => {
+    panningRef.current = false;
+  };
+
+  return { handleMouseMove, handleMouseDown, handleMouseUp };
+};

--- a/frontend/src/hooks/useUndoRedo.ts
+++ b/frontend/src/hooks/useUndoRedo.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+interface IPoint {
+  x: number;
+  y: number;
+}
+
+export const useUndoRedo = (initialPoints: IPoint[]) => {
+  const [points, setPoints] = useState<IPoint[]>(initialPoints);
+  const [undoStack, setUndoStack] = useState<IPoint[][]>([]);
+  const [redoStack, setRedoStack] = useState<IPoint[][]>([]);
+
+  const addPoint = (newPoint: IPoint) => {
+    setUndoStack(prev => [...prev, points]);
+    setPoints(prevPoints => [...prevPoints, newPoint]);
+    setRedoStack([]);
+  };
+
+  const undo = () => {
+    if (undoStack.length === 0) return;
+    setRedoStack(prev => [points, ...prev]);
+    setPoints(undoStack[undoStack.length - 1]);
+    setUndoStack(undoStack.slice(0, -1));
+  };
+
+  const redo = () => {
+    if (redoStack.length === 0) return;
+    setUndoStack(prev => [...prev, points]);
+    setPoints(redoStack[0]);
+    setRedoStack(redoStack.slice(1));
+  };
+
+  return { points, addPoint, undo, redo, undoStack, redoStack };
+};

--- a/frontend/src/hooks/useZoom.ts
+++ b/frontend/src/hooks/useZoom.ts
@@ -1,0 +1,45 @@
+import { useRef } from 'react';
+
+interface IUseZoomProps {
+  scaleRef: React.MutableRefObject<number>;
+  viewPosRef: React.MutableRefObject<{ x: number; y: number }>;
+  draw: () => void;
+  stepScales: number[];
+}
+
+const MIN_SCALE_INDEX = 0;
+const MAX_SCALE_INDEX = 15;
+
+export const useZoom = (props: IUseZoomProps) => {
+  const zoomIndexRef = useRef(7);
+
+  const handleWheel = (e: React.WheelEvent<HTMLCanvasElement>) => {
+    const viewPos = props.viewPosRef;
+    const scale = props.scaleRef;
+
+    if (!viewPos || scale.current === null) return;
+
+    e.preventDefault();
+    const { offsetX, offsetY } = e.nativeEvent;
+
+    if (e.deltaY < 0 && zoomIndexRef.current > MIN_SCALE_INDEX) {
+      zoomIndexRef.current -= 1;
+    } else if (e.deltaY > 0 && zoomIndexRef.current < MAX_SCALE_INDEX) {
+      zoomIndexRef.current += 1;
+    }
+
+    const newScale = 1 / props.stepScales[zoomIndexRef.current];
+    const xs = (offsetX - viewPos.current.x) / scale.current;
+    const ys = (offsetY - viewPos.current.y) / scale.current;
+
+    scale.current = newScale;
+    viewPos.current = {
+      x: offsetX - xs * scale.current,
+      y: offsetY - ys * scale.current,
+    };
+
+    props.draw();
+  };
+
+  return { handleWheel, zoomIndexRef };
+};

--- a/frontend/src/hooks/useZoom.ts
+++ b/frontend/src/hooks/useZoom.ts
@@ -5,13 +5,13 @@ interface IUseZoomProps {
   viewPosRef: React.MutableRefObject<{ x: number; y: number }>;
   draw: () => void;
   stepScales: number[];
+  initialZoomIndex: number;
 }
 
-const MIN_SCALE_INDEX = 0;
-const MAX_SCALE_INDEX = 15;
-
 export const useZoom = (props: IUseZoomProps) => {
-  const zoomIndexRef = useRef(7);
+  const zoomIndexRef = useRef(props.initialZoomIndex);
+  const MIN_SCALE_INDEX = 0;
+  const MAX_SCALE_INDEX = props.stepScales.length - 1;
 
   const handleWheel = (e: React.WheelEvent<HTMLCanvasElement>) => {
     const viewPos = props.viewPosRef;
@@ -28,7 +28,8 @@ export const useZoom = (props: IUseZoomProps) => {
       zoomIndexRef.current += 1;
     }
 
-    const newScale = 1 / props.stepScales[zoomIndexRef.current];
+    const newScale =
+      props.stepScales[props.initialZoomIndex] / props.stepScales[zoomIndexRef.current];
     const xs = (offsetX - viewPos.current.x) / scale.current;
     const ys = (offsetY - viewPos.current.y) / scale.current;
 


### PR DESCRIPTION
## 📝 PR 개요

- 캔버스에 전 찍어서 선 그리기
  - 점이 1개일 경우 점만 찍힘
  - 점이 2개 이상일 경우 선으로 이어짐
- 마우스를 눌러서 캔버스 내에 그림들 이동 가능
- 마우스 휠을 이용하여 캔버스 확대 / 축소 구현
- undo redo 기능

## ✅ 체크리스트 (Checklist)

- [x] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [x] 테스트가 통과하는지 확인
- [x] 스타일 가이드와 일관성을 유지했는지 확인
- [x] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [x] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인

## 🔄 관련 이슈 (Linked Issues)

#4 사용자가 지도에 자유롭게 선을 그을 수 있다
#201 undo 버튼을 누른다면 그렸던 최신 선의 하나가 지워진다
#202 redo 버튼을 누른다면 undo 했던 선의 하나가 복구된다


## 📷 스크린샷 및 동영상

https://github.com/user-attachments/assets/648ced2d-f47c-459d-8a6a-807e7c98d029


## 🧪 테스트 방법

- 페이지에서 ```<Linedrawer />```

