### PR TITLE
[FE][Feat] #14 : 바텀시트의 높이를 2단계 대신 자유롭게 변경할 수 있게 변경

### DIFF
--- a/frontend/src/component/BottomSheet/BottomSheet.tsx
+++ b/frontend/src/component/BottomSheet/BottomSheet.tsx
@@ -39,7 +39,7 @@ export const BottomSheet = (props: IBottomSheetProps) => {
   return (
     <div
       ref={sheet}
-      className="bg-grayscale-25 shadow-dark fixed left-0 right-0 z-[101] flex h-full flex-col rounded-t-lg transition-transform duration-700"
+      className="bg-grayscale-25 shadow-dark fixed left-0 right-0 z-[1000] flex h-full flex-col rounded-t-lg transition-transform duration-700"
       style={{
         top: `calc(100% - ${props.minHeight * 100}%)`,
       }}

--- a/frontend/src/component/common/modal/Modal.tsx
+++ b/frontend/src/component/common/modal/Modal.tsx
@@ -14,7 +14,7 @@ export const Modal = (props: IModalProps) => {
   if (!props.isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-20">
+    <div className="z-6000 fixed inset-0 flex items-center justify-center bg-black bg-opacity-20">
       <div className="relative w-[22rem] max-w-lg rounded-2xl bg-white px-6 shadow-lg">
         {props.children}
       </div>

--- a/frontend/src/component/content/Content.tsx
+++ b/frontend/src/component/content/Content.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { MdGroup, MdMoreVert } from 'react-icons/md';
 
 interface IContentProps {

--- a/frontend/src/component/content/Content.tsx
+++ b/frontend/src/component/content/Content.tsx
@@ -36,7 +36,7 @@ export const Content = (props: IContentProps) => {
       className="relative flex w-full flex-row items-center justify-between px-4 py-5"
     >
       <div>
-        <header className="border-b border-gray-200 pb-1 text-lg">{props.title}</header>
+        <header className="border-gray-200 pb-1 text-lg">{props.title}</header>
         <section className="flex items-center text-sm leading-5 text-gray-500">
           <time className="mr-4">시간</time>
           <span className="mr-6">{props.time}</span>

--- a/frontend/src/hooks/useBottomSheet.ts
+++ b/frontend/src/hooks/useBottomSheet.ts
@@ -71,28 +71,6 @@ export function useBottomSheet(props: IUseBottomSheet) {
     sheet.current!.style.transform = `translateY(${nextY - MAX_Y}px)`;
   };
 
-  const handleEnd = () => {
-    const { touchMove } = metrics.current;
-    const currentY = sheet.current!.getBoundingClientRect().y;
-
-    if (touchMove.movingDirection === 'up' && currentY < (MIN_Y + MAX_Y) / 2) {
-      sheet.current!.style.transform = `translateY(${MIN_Y - MAX_Y}px)`;
-    } else {
-      sheet.current!.style.transform = `translateY(0px)`;
-    }
-
-    document.body.style.overflowY = 'auto';
-
-    window.removeEventListener('mousemove', handleMove);
-    window.removeEventListener('mouseup', handleEnd);
-
-    metrics.current = {
-      touchStart: { sheetY: 0, touchY: 0 },
-      touchMove: { prevTouchY: 0, movingDirection: 'none' },
-      isContentAreaTouched: false,
-    };
-  };
-
   useEffect(() => {
     const handleStart = (e: TouchEvent | MouseEvent) => {
       const clientY = getClientY(e);
@@ -103,24 +81,20 @@ export function useBottomSheet(props: IUseBottomSheet) {
 
       if (e instanceof MouseEvent) {
         window.addEventListener('mousemove', handleMove);
-        window.addEventListener('mouseup', handleEnd);
       }
     };
 
     sheet.current?.addEventListener('touchstart', handleStart);
     sheet.current?.addEventListener('touchmove', handleMove);
-    sheet.current?.addEventListener('touchend', handleEnd);
 
     sheet.current?.addEventListener('mousedown', handleStart);
 
     return () => {
       sheet.current?.removeEventListener('touchstart', handleStart);
       sheet.current?.removeEventListener('touchmove', handleMove);
-      sheet.current?.removeEventListener('touchend', handleEnd);
 
       sheet.current?.removeEventListener('mousedown', handleStart);
       window.removeEventListener('mousemove', handleMove);
-      window.removeEventListener('mouseup', handleEnd);
     };
   }, []);
 

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { getUserLocation } from '@/hooks/getUserLocation';
 import { Map } from '@/component/maps/Map';
-import { BottomSheet } from '@/component/bottomSheet/BottomSheet';
+import { BottomSheet } from '@/component/bottomsheet/BottomSheet';
 import { Content } from '@/component/content/Content';
 import { MdFormatListBulleted } from 'react-icons/md';
 
@@ -31,7 +31,7 @@ const contentData = [
 
 export const Main = () => {
   const { lat, lng, error } = getUserLocation();
-  const MIN_HEIGHT = 0.5;
+  const MIN_HEIGHT = 0.03;
   const MAX_HEIGHT = 0.8;
 
   return (


### PR DESCRIPTION
## 📝 PR 개요

- 바텀시트의 높이를 2단계 대신 자유롭게 변경할 수 있게 변경
- 바텀시트 최저 높이 변경
- 불필요한 코드 삭제
- z-index 조절

## ✅ 체크리스트 (Checklist)

- [x] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [x] 테스트가 통과하는지 확인
- [x] 스타일 가이드와 일관성을 유지했는지 확인
- [x] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [x] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인

## 🔄 관련 이슈 (Linked Issues)

#14 바텀시트 내부의 경로 목록 컴포넌트

## 📷 스크린샷 및 동영상 

https://github.com/user-attachments/assets/64754a80-d3ec-41ff-a017-9d2cc77a3133







