### PR TITLE
[BE][Feat] #219 : 헤더의 JWT 토큰으로 사용자 검증 middleware 추가

### DIFF
--- a/backend/src/middleware/authenticateJWT.js
+++ b/backend/src/middleware/authenticateJWT.js
@@ -1,0 +1,18 @@
+import jwt from 'jsonwebtoken';
+
+export const authenticateJWT = (req, res, next) => {
+  const token = req.header('Authorization')?.replace('Bearer ', '');
+
+  if (!token) {
+    return res.status(403).json({ message: 'Access Denied: No Token Provided' });
+  }
+
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) {
+      return res.status(403).json({ message: 'Invalid Token' });
+    }
+
+    req.user = user;
+    next();
+  });
+};

--- a/backend/src/routes/channelRouter.js
+++ b/backend/src/routes/channelRouter.js
@@ -8,6 +8,7 @@ import {
   getUserChannelsController,
 } from '../controllers/channelController.js';
 import { validationMiddleware } from '../middleware/validationMiddleware.js';
+import { authenticateJWT } from '../middleware/authenticateJWT.js';
 
 export const channelRouter = express.Router();
 
@@ -40,6 +41,7 @@ channelRouter.post(
     body('name').notEmpty().withMessage('Name is required'),
     body('host_id').notEmpty().withMessage('Host ID is required'),
   ],
+  authenticateJWT,
   validationMiddleware,
   createChannelController,
 );
@@ -77,6 +79,7 @@ channelRouter.post(
 channelRouter.post(
   '/:channelId/guests',
   [body('guests').isArray().withMessage('Guests must be an array')],
+  authenticateJWT,
   validationMiddleware,
   addGuestController,
 );
@@ -108,6 +111,7 @@ channelRouter.post(
 channelRouter.get(
   '/:id',
   [param('id').notEmpty().withMessage('Channel ID is required')],
+  authenticateJWT,
   validationMiddleware,
   getChannelInfoController,
 );
@@ -182,6 +186,7 @@ channelRouter.get(
 channelRouter.get(
   '/user/:userId',
   [param('userId').notEmpty().withMessage('User ID is required')],
+  authenticateJWT,
   validationMiddleware,
   getUserChannelsController,
 );


### PR DESCRIPTION

## 📝 PR 개요

 헤더의 JWT 토큰으로 사용자 검증 middleware 추가

---

## 🔍 변경 사항

- 사용자 검증 middleware 함수 구현
- 일부 api에 사용자 검증 middleware 추가


---

## ✅ 체크리스트 (Checklist)

- [X] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [X] 테스트가 통과하는지 확인
- [X] 스타일 가이드와 일관성을 유지했는지 확인
- [X] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [X] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인


---

## 🔄 관련 이슈 (Linked Issues)

#219 


---

## 🧪 테스트 방법

- 헤더에 token 넣지 않은 상태로 api 요청시 실패

![image](https://github.com/user-attachments/assets/c9f28d3f-52f0-4750-b929-fab31642034e)


- 헤더에 토큰 넣은 상태로 api 요청시 성공

![image](https://github.com/user-attachments/assets/259eb7db-9ca9-457f-a275-d02e50470c2e)