### PR TITLE
[FE][Feat] #224 : 캔버스와 지도 연동

### DIFF
--- a/frontend/src/component/canvas/Canvas.tsx
+++ b/frontend/src/component/canvas/Canvas.tsx
@@ -1,5 +1,13 @@
 import classNames from 'classnames';
-import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { useDrawing } from '@/hooks/useDrawing.ts';
+import { usePanning } from '@/hooks/usePanning.ts';
+import { useZoom } from '@/hooks/useZoom.ts';
+import { MdArrowCircleLeft, MdArrowCircleRight } from 'react-icons/md';
+import { useUndoRedo } from '@/hooks/useUndoRedo.ts';
+import { ButtonState } from '@/component/common/enums.ts';
+import { useFloatingButton } from '@/hooks/useFloatingButton.ts';
+import { FloatingButton } from '@/component/common/floatingbutton/FloatingButton.tsx';
 
 interface ICanvasProps {
   className?: string;
@@ -9,13 +17,38 @@ interface ICanvasProps {
   // onMouseMove?: () => void;
 }
 
+interface IPoint {
+  x: number;
+  y: number;
+}
+
+// 네이버 지도 기준 확대/축소 비율 단계
+const NAVER_STEP_SCALES = [
+  100, 100, 100, 100, 100, 100, 50, 30, 20, 10, 5, 3, 1, 0.5, 0.3, 0.1, 0.05, 0.03, 0.02, 0.01,
+  0.005,
+];
+
+// 선의 굵기 상수
+const LINE_WIDTH = 2;
+// 선의 색 상수
+const STROKE_STYLE = 'black';
+// 지도의 처음 확대/축소 비율 단계 index
+const INITIAL_ZOOM_INDEX = 12;
+
 export interface ICanvasRefMethods {
   getCanvasElement: () => HTMLCanvasElement | null;
-  onMouseClickHandler: (event?: React.MouseEvent) => void;
+  onMouseClickHandler: (event: React.MouseEvent) => void;
+  onMouseDownHandler: (event: React.MouseEvent) => void;
+  onMouseMoveHandler: (event: React.MouseEvent) => void;
+  onMouseUpHandler: (event: React.MouseEvent) => void;
 }
 
 export const Canvas = forwardRef<ICanvasRefMethods, ICanvasProps>((props, ref) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { points, addPoint, undo, redo, undoStack, redoStack } = useUndoRedo([]);
+  const [startPoint, setStartPoint] = useState<IPoint | null>(null);
+  const [endPoint, setEndPoint] = useState<IPoint | null>(null);
+  const { isMenuOpen, toolType, toggleMenu, handleMenuClick } = useFloatingButton();
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -28,20 +61,110 @@ export const Canvas = forwardRef<ICanvasRefMethods, ICanvasProps>((props, ref) =
     canvas.height = canvas.offsetHeight;
   }, []);
 
+  const { draw, scaleRef, viewPosRef } = useDrawing({
+    canvasRef,
+    points,
+    startPoint,
+    endPoint,
+    lineWidth: LINE_WIDTH,
+    strokeStyle: STROKE_STYLE,
+    initialScale: NAVER_STEP_SCALES[INITIAL_ZOOM_INDEX],
+  });
+
+  const { handleMouseMove, handleMouseDown, handleMouseUp } = usePanning({ viewPosRef, draw });
+  const { handleWheel } = useZoom({
+    scaleRef,
+    viewPosRef,
+    draw,
+    stepScales: NAVER_STEP_SCALES,
+    initialZoomIndex: INITIAL_ZOOM_INDEX,
+  });
+
+  const handleCanvasClick = (e: React.MouseEvent) => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+
+    const x = (e.clientX - rect.left - viewPosRef.current.x) / scaleRef.current;
+    const y = (e.clientY - rect.top - viewPosRef.current.y) / scaleRef.current;
+
+    switch (toolType) {
+      case ButtonState.LINE_DRAWING:
+        addPoint({ x, y });
+        break;
+      case ButtonState.START_MARKER:
+        setStartPoint({ x, y });
+        break;
+      case ButtonState.DESTINATION_MARKER:
+        setEndPoint({ x, y });
+        break;
+      default:
+        addPoint({ x, y });
+        break;
+    }
+
+    draw();
+  };
+
   useImperativeHandle(ref, () => ({
     getCanvasElement: () => canvasRef.current ?? null,
     onMouseClickHandler: event => {
-      console.log(event?.screenX, event?.screenY);
+      handleCanvasClick(event);
+    },
+    onMouseDownHandler: event => {
+      handleMouseDown(event);
+    },
+    onMouseUpHandler: () => {
+      handleMouseUp();
+    },
+    onMouseMoveHandler: event => {
+      handleMouseMove(event);
     },
   }));
 
   return (
-    <canvas
-      ref={canvasRef}
-      className={classNames(
-        'z-1000 pointer-events-none absolute h-full w-full bg-transparent',
-        props.className,
-      )}
-    />
+    <div className="absolute h-full w-full">
+      <div className="absolute left-1/2 top-[10px] z-10 flex -translate-x-1/2 transform gap-2">
+        <button
+          type="button"
+          onClick={undo}
+          disabled={undoStack.length === 0}
+          className={`h-[35px] w-[35px] ${
+            undoStack.length === 0 ? 'cursor-not-allowed opacity-50' : ''
+          }`}
+        >
+          <MdArrowCircleLeft size={24} />
+        </button>
+        <button
+          type="button"
+          onClick={redo}
+          disabled={redoStack.length === 0}
+          className={`h-[35px] w-[35px] ${
+            redoStack.length === 0 ? 'cursor-not-allowed opacity-50' : ''
+          }`}
+        >
+          <MdArrowCircleRight size={24} />
+        </button>
+      </div>
+      <canvas
+        ref={canvasRef}
+        className={classNames(
+          'z-1000 pointer-events-none absolute h-full w-full bg-transparent',
+          props.className,
+        )}
+        onClick={handleCanvasClick}
+        onMouseMove={handleMouseMove}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onWheel={handleWheel}
+      />
+      <div className="absolute">
+        <FloatingButton
+          isMenuOpen={isMenuOpen}
+          toggleMenu={toggleMenu}
+          toolType={toolType}
+          handleMenuClick={handleMenuClick}
+        />
+      </div>
+    </div>
   );
 });

--- a/frontend/src/component/canvas/Canvas.tsx
+++ b/frontend/src/component/canvas/Canvas.tsx
@@ -11,6 +11,7 @@ interface ICanvasProps {
 
 export interface ICanvasRefMethods {
   getCanvasElement: () => HTMLCanvasElement | null;
+  onMouseClickHandler: (event?: React.MouseEvent) => void;
 }
 
 export const Canvas = forwardRef<ICanvasRefMethods, ICanvasProps>((props, ref) => {
@@ -25,12 +26,13 @@ export const Canvas = forwardRef<ICanvasRefMethods, ICanvasProps>((props, ref) =
 
     canvas.width = canvas.offsetWidth;
     canvas.height = canvas.offsetHeight;
-
-    context.fillRect(0, 0, 200, 200);
   }, []);
 
   useImperativeHandle(ref, () => ({
     getCanvasElement: () => canvasRef.current ?? null,
+    onMouseClickHandler: event => {
+      console.log(event?.screenX, event?.screenY);
+    },
   }));
 
   return (

--- a/frontend/src/component/canvas/CanvasWithMap.tsx
+++ b/frontend/src/component/canvas/CanvasWithMap.tsx
@@ -1,4 +1,4 @@
-import { Canvas, ICanvasRefMethods } from '@/component/canvas/Canvas.tsx';
+import { Canvas, ICanvasRefMethods } from '@/component/canvas/LineDrawer_test.tsx';
 import { Map, IMapRefMethods } from '@/component/maps/Map.tsx';
 import classNames from 'classnames';
 import { ICanvasVertex } from '@/utils/screen/canvasUtils.ts';
@@ -33,35 +33,36 @@ const MouseEventStateInitialValue = {
 };
 
 export const CanvasWithMap = (props: ICanvasWithMapProps) => {
-  const mapRef = useRef<IMapRefMethods | null>(null);
+  const mapRefMethods = useRef<IMapRefMethods | null>(null);
   const mapElement = useRef<HTMLElement | null>(null);
-  const canvasMethods = useRef<ICanvasRefMethods | null>(null);
+  const canvasRefMethods = useRef<ICanvasRefMethods | null>(null);
   const canvasElement = useRef<HTMLCanvasElement | null>(null);
   const mouseEventState = useRef<IMouseEventState>({ ...MouseEventStateInitialValue });
   const [mapObject, setMapObject] = useState<naver.maps.Map | null>(null);
 
   useEffect(() => {
-    if (canvasMethods.current?.getCanvasElement)
-      canvasElement.current = canvasMethods.current.getCanvasElement();
+    if (canvasRefMethods.current?.getCanvasElement)
+      canvasElement.current = canvasRefMethods.current.getCanvasElement();
   }, []);
 
   useEffect(() => {
-    mapElement.current = mapRef.current?.getMapContainer() ?? null;
+    mapElement.current = mapRefMethods.current?.getMapContainer() ?? null;
   }, [mapObject]);
 
   const initMap = (mapObj: naver.maps.Map | null) => {
     setMapObject(mapObj);
   };
 
-  const handleClick = () => {
-    mapElement.current?.click();
-    canvasElement.current?.click();
+  const handleClick = (event: React.MouseEvent) => {
+    mapRefMethods.current?.onMouseClickHandler(event);
+    canvasRefMethods.current?.onMouseClickHandler(event);
   };
 
   const handleMouseDown = (event: React.MouseEvent<HTMLElement>) => {
     if (!mapElement.current || !canvasElement.current) return;
     mouseEventState.current.isMouseDown = true;
     mouseEventState.current.mouseDownPosition = { x: event.clientX, y: event.clientY };
+    canvasRefMethods.current?.onMouseDownHandler(event);
   };
 
   const handleMouseMove = (event: React.MouseEvent<HTMLElement>) => {
@@ -70,8 +71,8 @@ export const CanvasWithMap = (props: ICanvasWithMapProps) => {
 
     // TODO: 쓰로틀링 걸기
     mouseEventState.current.mouseDeltaPosition = {
-      x: event.clientX - mouseEventState.current.mouseDownPosition.x,
-      y: event.clientY - mouseEventState.current.mouseDownPosition.y,
+      x: -(event.clientX - mouseEventState.current.mouseDownPosition.x),
+      y: -(event.clientY - mouseEventState.current.mouseDownPosition.y),
     };
 
     mapObject?.panBy(
@@ -80,11 +81,14 @@ export const CanvasWithMap = (props: ICanvasWithMapProps) => {
         mouseEventState.current.mouseDeltaPosition.y,
       ),
     );
+
+    canvasRefMethods.current?.onMouseMoveHandler(event);
   };
 
-  const handleMouseUp = () => {
+  const handleMouseUp = (event: React.MouseEvent) => {
     if (!mapElement.current || !canvasElement.current) return;
     mouseEventState.current = { ...MouseEventStateInitialValue };
+    canvasRefMethods.current?.onMouseUpHandler(event);
   };
 
   return (
@@ -95,13 +99,13 @@ export const CanvasWithMap = (props: ICanvasWithMapProps) => {
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
     >
-      <Canvas ref={canvasMethods} />
+      <Canvas ref={canvasRefMethods} />
       <Map
         lat={props.lat}
         lng={props.lng}
         type={props.mapType}
         zoom={props.zoom}
-        ref={mapRef}
+        ref={mapRefMethods}
         initMap={initMap}
       />
     </div>

--- a/frontend/src/component/canvas/CanvasWithMap.tsx
+++ b/frontend/src/component/canvas/CanvasWithMap.tsx
@@ -1,4 +1,4 @@
-import { Canvas, ICanvasRefMethods } from '@/component/canvas/LineDrawer_test.tsx';
+import { Canvas, ICanvasRefMethods } from '@/component/canvas/Canvas.tsx';
 import { Map, IMapRefMethods } from '@/component/maps/Map.tsx';
 import classNames from 'classnames';
 import { ICanvasVertex } from '@/utils/screen/canvasUtils.ts';

--- a/frontend/src/component/maps/Map.tsx
+++ b/frontend/src/component/maps/Map.tsx
@@ -20,6 +20,7 @@ interface IMapProps extends IMapOptions {
 export interface IMapRefMethods {
   getMapObject: () => naver.maps.Map | null;
   getMapContainer: () => HTMLElement | null;
+  onMouseClickHandler: (event?: React.MouseEvent) => void;
 }
 
 const validateKindOfMap = (type: string) => ['naver'].includes(type);
@@ -59,6 +60,7 @@ export const Map = forwardRef<IMapRefMethods, IMapProps>((props, ref) => {
   useImperativeHandle(ref, () => ({
     getMapObject: () => mapObject,
     getMapContainer: () => mapContainer.current,
+    onMouseClickHandler: () => {},
   }));
 
   return (

--- a/frontend/src/component/maps/NaverMap.tsx
+++ b/frontend/src/component/maps/NaverMap.tsx
@@ -30,14 +30,11 @@ export const NaverMap = forwardRef<IMapRefMethods, INaverMapProps>((props, ref) 
     }
   }, [mapOptions]);
 
-  const clickHandler = () => {
-    console.log('clicked!');
-  };
-
   useImperativeHandle(ref, () => ({
     getMapObject: () => naverMapObject.current,
     getMapContainer: () => naverMapContainer.current,
+    onMouseClickHandler: () => {},
   }));
 
-  return <section ref={naverMapContainer} className="h-full w-full" onClick={clickHandler} />;
+  return <section ref={naverMapContainer} className="h-full w-full" />;
 });

--- a/frontend/src/hooks/usePanning.ts
+++ b/frontend/src/hooks/usePanning.ts
@@ -11,7 +11,7 @@ export const usePanning = (props: IUsePanningProps) => {
   const panningRef = useRef(false);
   const startPosRef = useRef(INITIAL_POSITION);
 
-  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+  const handleMouseMove = (e: React.MouseEvent) => {
     if (!panningRef.current || !props.viewPosRef.current) return;
 
     const viewPos = props.viewPosRef.current;
@@ -23,7 +23,7 @@ export const usePanning = (props: IUsePanningProps) => {
     props.draw();
   };
 
-  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+  const handleMouseDown = (e: React.MouseEvent) => {
     if (!props.viewPosRef.current) return;
 
     const viewPos = props.viewPosRef.current;


### PR DESCRIPTION
## 📝 PR 개요

캔버스와 지도 연동

## 🔍 변경 사항

- 캔버스와 지도 이벤트 연동
- 캔버스에 그림이 그려진 상태로 지도와 같이 움직일 수 있도록 구현

## ✅ 체크리스트 (Checklist)

- [x] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [x] 테스트가 통과하는지 확인
- [x] 스타일 가이드와 일관성을 유지했는지 확인
- [x] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [x] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인

## 🔄 관련 이슈 (Linked Issues)

#244

## 📷 스크린샷 및 동영상 (선택 사항)

https://github.com/user-attachments/assets/8a934589-a99c-4c42-9bd5-05b935b15506
