### PR TITLE
지도 가져올 때 로딩 화면 추가 (로딩 스피너로 대체)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -44,3 +44,22 @@
   -ms-user-select:none;
   user-select:none
 }
+
+.spinner {
+  width: 3rem;
+  height: 3rem;
+  border: 0.5rem solid rgba(0, 0, 0, 0.1);
+  border-top: 0.5rem solid #1c58b3;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 10px;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/frontend/src/component/common/loadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/component/common/loadingSpinner/LoadingSpinner.tsx
@@ -1,3 +1,8 @@
 export const LoadingSpinner = () => {
-  return <div className="spinner" />;
+  return (
+    <section className="flex h-full flex-col items-center justify-center gap-2 text-xl text-gray-700">
+      <div className="spinner" />
+      Loading map data...
+    </section>
+  );
 };

--- a/frontend/src/component/common/loadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/component/common/loadingSpinner/LoadingSpinner.tsx
@@ -1,0 +1,3 @@
+export const LoadingSpinner = () => {
+  return <div className="spinner" />;
+};

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -104,10 +104,7 @@ export const Main = () => {
               otherLocations={otherLocations}
             />
           ) : (
-            <section className="flex h-full flex-col items-center justify-center gap-2 text-xl text-gray-700">
-              <LoadingSpinner />
-              Loading map data...
-            </section>
+            <LoadingSpinner />
           )
         ) : (
           <section className="flex h-full flex-col items-center justify-center gap-2 text-xl text-gray-700">

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -10,6 +10,7 @@ import { AppConfig } from '@/lib/constants/commonConstants.ts';
 import { v4 as uuidv4 } from 'uuid';
 import { getUserLocation } from '@/hooks/getUserLocation.ts';
 import { MapCanvasForView } from '@/component/canvasWithMap/canvasWithMapForView/MapCanvasForView.tsx';
+import { LoadingSpinner } from '@/component/common/loadingSpinner/LoadingSpinner.tsx';
 
 const contentData = [
   {
@@ -103,13 +104,15 @@ export const Main = () => {
               otherLocations={otherLocations}
             />
           ) : (
-            <section className="flex h-full items-center justify-center">
+            <section className="flex h-full flex-col items-center justify-center gap-2 text-xl text-gray-700">
+              <LoadingSpinner />
               Loading map data...
             </section>
           )
         ) : (
-          <section className="flex h-full items-center justify-center">
-            {error ? `Error: ${error}` : 'Loading'}
+          <section className="flex h-full flex-col items-center justify-center gap-2 text-xl text-gray-700">
+            <LoadingSpinner />
+            {error ? `Error: ${error}` : 'Loading map data...'}
           </section>
         )}
       </main>


### PR DESCRIPTION

## 📝 PR 개요

지도 가져올 때 로딩 화면 추가 (로딩 스피너로 대체)

---

## 🔍 변경 사항

- 지도 가져올 때 로딩 화면 추가 (로딩 스피너로 대체)
- 홈 화면에서 지도 로딩 화면 적용

@effozen @leedongyull 님 바쁘지 않으실 때 지도 각 페이지에서 사용하실 때, 이 컴포넌트 사용해서 로딩 관련 로직 추가 부탁드립니다!


---

## ✅ 체크리스트 (Checklist)

- [X] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [X] 테스트가 통과하는지 확인
- [X] 스타일 가이드와 일관성을 유지했는지 확인
- [X] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [X] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인


---

## 🔄 관련 이슈 (Linked Issues)

#274

---

## 📷 스크린샷 및 동영상 (선택 사항)
![ddara-mapconnect-test15](https://github.com/user-attachments/assets/cb219bda-dfac-43b6-a463-5d309b7f86d5)



---
