### PR TITLE
[FE][Feat] #314 : 마커 설정 시 줌 기능 구현

### DIFF
--- a/frontend/src/component/canvasWithMap/canvasWithMapforDraw/MapCanvasForDraw.tsx
+++ b/frontend/src/component/canvasWithMap/canvasWithMapforDraw/MapCanvasForDraw.tsx
@@ -445,6 +445,56 @@ export const MapCanvasForDraw = ({
     updateCanvasSize();
   }, [map]);
 
+  const calculateZoomLevel = (latDiff: number, lngDiff: number) => {
+    const maxDiff = Math.max(latDiff, lngDiff);
+    if (maxDiff < 0.0005) return 19;
+    if (maxDiff < 0.001) return 18;
+    if (maxDiff < 0.004) return 17;
+    if (maxDiff < 0.01) return 15;
+    if (maxDiff < 0.03) return 14;
+    if (maxDiff < 0.05) return 13;
+    if (maxDiff < 0.1) return 12;
+    if (maxDiff < 0.2) return 11;
+    if (maxDiff < 0.5) return 10;
+    if (maxDiff < 1) return 9;
+    if (maxDiff < 2) return 8;
+    if (maxDiff < 5) return 7;
+    if (maxDiff < 10) return 6;
+    return 5;
+  };
+
+  useEffect(() => {
+    if (startMarker && endMarker) {
+      const latitudes = [startMarker.lat, endMarker.lat];
+      const longitudes = [startMarker.lng, endMarker.lng];
+
+      const maxLat = Math.max(...latitudes);
+      const minLat = Math.min(...latitudes);
+      const maxLng = Math.max(...longitudes);
+      const minLng = Math.min(...longitudes);
+
+      const centerLat = (maxLat + minLat) / 2;
+      const centerLng = (maxLng + minLng) / 2;
+
+      map?.setCenter(new window.naver.maps.LatLng(centerLat, centerLng));
+
+      const latDiff = maxLat - minLat;
+      const lngDiff = maxLng - minLng;
+      const zoomLevel = calculateZoomLevel(latDiff, lngDiff);
+
+      map?.setZoom(zoomLevel);
+    } else {
+      if (startMarker) {
+        map?.setCenter({ lat: startMarker.lat, lng: startMarker.lng });
+        map?.setZoom(15);
+      }
+      if (endMarker) {
+        map?.setCenter({ lat: endMarker.lat, lng: endMarker.lng });
+        map?.setZoom(15);
+      }
+    }
+  }, [startMarker, endMarker]);
+
   useEffect(() => {
     redrawCanvas();
   }, [startMarker, endMarker, pathPoints, map, undoStack, redoStack]);

--- a/frontend/src/component/routebutton/RouteResultButton.tsx
+++ b/frontend/src/component/routebutton/RouteResultButton.tsx
@@ -28,8 +28,8 @@ export const RouteResultButton = (props: IRouteResultButtonProps) => {
       .writeText(url)
       .then(() => {
         alert(
-          `${channelInfo.name} 경로의 링크가 복사되었습니다\n 사용자에게 링크를 보내주세요!\n\n ${url}`,
-        ); // 복사 성공 메시지
+          `${channelInfo.name} 경로의 링크가 복사되었습니다\n사용자에게 링크를 보내주세요!\n\n${url}`,
+        );
       })
       .catch(() => {
         alert('링크 복사에 실패했습니다.'); // 복사 실패 시 처리


### PR DESCRIPTION
## 📝 PR 개요

- 마커 설정 시 줌 기능 구현
- 검색으로 찍은 마커, 플로팅 버튼으로 찍은 마커 둘다 적용
- 출발지, 도착지 모두 보이게 화면 확대

---

## ✅ 체크리스트 (Checklist)

- [x] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [x] 테스트가 통과하는지 확인
- [x] 스타일 가이드와 일관성을 유지했는지 확인
- [x] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [x] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인

---

## 🔄 관련 이슈 (Linked Issues)

#314 

---

## 📷 스크린샷 및 동영상 (선택 사항)

https://github.com/user-attachments/assets/69aaf067-8aad-4d7c-8a2d-b231190155ec

- 검색, 직접 설정 둘 다 화면 확대
- 만약 두 마커가 모두 찍혀있다면 좌표 거리 계산하여 화면 확대

---

## 📚 참고 사항

- GPT가 계산식 만들어줘서 useEffect로 구현했습니다!!
- 자세한 수치는 옆에 콘솔 찍어보면서 노가다 했습니다..ㅎㅎ

---