### PR TITLE
[FE][Feat] #321 : 현재 위치 추적이 실시간을 되지 않는 문제 해결

### DIFF
--- a/frontend/src/hooks/getUserLocation.ts
+++ b/frontend/src/hooks/getUserLocation.ts
@@ -37,7 +37,7 @@ export const getUserLocation = (): IGetUserLocation => {
 
   useEffect(() => {
     if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
+      const watchId = navigator.geolocation.watchPosition(
         position => {
           setLocation({
             lat: position.coords.latitude,
@@ -52,14 +52,16 @@ export const getUserLocation = (): IGetUserLocation => {
             error: error.message,
           });
         },
+        { enableHighAccuracy: true, maximumAge: 5000, timeout: 10000 },
       );
-    } else {
-      setLocation({
-        lat: 37.3595704,
-        lng: 127.105399,
-        error: '현재 위치를 불러오지 못했습니다',
-      });
+
+      return () => navigator.geolocation.clearWatch(watchId);
     }
+    setLocation({
+      lat: 37.3595704,
+      lng: 127.105399,
+      error: '현재 위치를 불러오지 못했습니다',
+    });
   }, []);
 
   return location;


### PR DESCRIPTION


## 📝 PR 개요

현재 위치 추적이 실시간을 되지 않는 문제 해결

---

## 🔍 변경 사항

- geolocation API의 watchPosition 사용으로 변경
- 나의 현재 위치 실시간 반영
- 다른 사용자의 현재 위치 실시간 반영


---

## ✅ 체크리스트 (Checklist)

- [X] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [X] 테스트가 통과하는지 확인
- [X] 스타일 가이드와 일관성을 유지했는지 확인
- [X] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [X] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인


---




## 🔄 관련 이슈 (Linked Issues)



#321 

---

## 📷 스크린샷 및 동영상 (선택 사항)

위도/경도를 이렇게 임의로 조작해서, 이 상태를 모바일 (다른 디바이스)에서도 잘 받아오는지 테스트 진행했습니다.

https://github.com/user-attachments/assets/ed4a7d0c-e249-495f-9563-eb3aaeef0020


![ddara-mapconnect-test16](https://github.com/user-attachments/assets/8b5b0961-d7a6-4062-86a2-15e49b08e806)


---


