### PR TITLE
[FE][Feat] : 바텀시트, 메인페이지 QA 작업

### DIFF
--- a/frontend/src/component/bottomsheet/BottomSheet.tsx
+++ b/frontend/src/component/bottomsheet/BottomSheet.tsx
@@ -14,9 +14,9 @@ export const BottomSheet = ({
   backgroundColor,
   children,
 }: IBottomSheetProps) => {
-  const [sheetHeight, setSheetHeight] = useState(minHeight);
+  const [sheetHeight, setSheetHeight] = useState(minHeight + 0.2);
   const startY = useRef(0);
-  const startHeight = useRef(minHeight);
+  const startHeight = useRef(minHeight + 0.2);
 
   const handleStart = (y: number) => {
     startY.current = y;

--- a/frontend/src/component/bottomsheet/BottomSheet.tsx
+++ b/frontend/src/component/bottomsheet/BottomSheet.tsx
@@ -58,11 +58,10 @@ export const BottomSheet = ({
 
   return (
     <div
-      className="fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-white shadow-lg transition-transform duration-700 ease-out"
+      className="transition-height fixed bottom-0 left-0 right-0 z-50 rounded-t-2xl bg-white shadow-lg duration-700 ease-out"
       style={{
         backgroundColor: `${backgroundColor}`,
         height: `${sheetHeight * 100}vh`,
-        transform: `translateY(${(1 - sheetHeight) * 100}%)`,
       }}
     >
       <div
@@ -73,6 +72,7 @@ export const BottomSheet = ({
       >
         <div className="h-1.5 w-12 rounded-full bg-gray-300" />
       </div>
+
       <div className="absolute right-2 top-2">
         <button
           onClick={handleClose}

--- a/frontend/src/component/canvasWithMap/canvasWithMapForView/MapCanvasForView.tsx
+++ b/frontend/src/component/canvasWithMap/canvasWithMapForView/MapCanvasForView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ICanvasPoint, IMapCanvasViewProps, IPoint } from '@/lib/types/canvasInterface.ts';
 import { useCanvasInteraction } from '@/hooks/useCanvasInteraction';
 import { useRedrawCanvas } from '@/hooks/useRedraw';
+import { ZoomSlider } from '@/component/zoomslider/ZoomSlider';
 
 export const MapCanvasForView = ({
   lat,
@@ -123,6 +124,9 @@ export const MapCanvasForView = ({
           pointerEvents: 'auto',
         }}
       />
+      <div className="absolute right-2 top-4 z-10 flex gap-2">
+        <ZoomSlider map={map} redrawCanvas={redrawCanvas} />
+      </div>
     </div>
   );
 };

--- a/frontend/src/component/content/Content.tsx
+++ b/frontend/src/component/content/Content.tsx
@@ -106,12 +106,13 @@ export const Content = (props: IContentProps) => {
   }, [channelInfo, navigate]);
 
   return (
-    <div className="relative flex w-full flex-row items-center justify-between px-4 py-5">
-      <div
-        onClick={() => {
-          navigate(props.link);
-        }}
-      >
+    <div
+      className="relative flex w-full flex-row items-center justify-between px-4 py-5"
+      onClick={() => {
+        navigate(props.link);
+      }}
+    >
+      <div>
         <header className="border-gray-200 pb-1 text-lg">{props.title}</header>
         <section className="flex items-center text-sm leading-5 text-gray-500">
           <time className="mr-4">
@@ -125,7 +126,12 @@ export const Content = (props: IContentProps) => {
           )}
         </section>
       </div>
-      <div className="relative">
+      <div
+        className="relative"
+        onClick={e => {
+          e.stopPropagation();
+        }}
+      >
         <Dropdown>
           <Dropdown.Trigger>
             <MdMoreVert className="h-6 w-6" />

--- a/frontend/src/component/zoomslider/ZoomSlider.tsx
+++ b/frontend/src/component/zoomslider/ZoomSlider.tsx
@@ -22,14 +22,14 @@ const ZoomButton = ({ label, onClick }: IZoomButtonProps) => (
   <button
     type="button"
     onClick={onClick}
-    className="text-grayscale-500 flex w-full items-center justify-center rounded border-b py-2 focus:outline-none"
+    className="text-grayscale-500 flex w-full items-center justify-center rounded border-b border-t py-2 focus:outline-none"
   >
     {label}
   </button>
 );
 
 const ZoomSliderInput = ({ zoomLevel, onSliderChange }: IZoomSliderInputProps) => (
-  <div className="relative flex w-[200px] flex-grow items-center justify-center px-2">
+  <div className="relative flex w-[130px] flex-grow items-center justify-center px-1">
     <input
       type="range"
       min="6"
@@ -43,9 +43,9 @@ const ZoomSliderInput = ({ zoomLevel, onSliderChange }: IZoomSliderInputProps) =
       }}
     />
     <div
-      className="absolute h-full w-1 bg-blue-500"
+      className="absolute flex items-center justify-center"
       style={{
-        height: `${((zoomLevel - 6) / 17) * 100}%`,
+        height: '100%',
         bottom: 0,
       }}
     />
@@ -83,7 +83,7 @@ export const ZoomSlider = ({ map, redrawCanvas }: IZoomSliderProps) => {
   };
 
   return (
-    <div className="flex h-64 w-9 flex-col items-center rounded bg-white shadow">
+    <div className="flex h-48 w-9 flex-col items-center rounded bg-white shadow">
       <ZoomButton label={<MdOutlineAdd />} onClick={() => handleZoomChange(1)} />
       <ZoomSliderInput zoomLevel={zoomLevel} onSliderChange={handleSliderChange} />
       <ZoomButton label={<MdRemove />} onClick={() => handleZoomChange(-1)} />

--- a/frontend/src/hooks/useRedraw.ts
+++ b/frontend/src/hooks/useRedraw.ts
@@ -72,10 +72,9 @@ export const useRedrawCanvas = ({
     ctx: CanvasRenderingContext2D,
     point: { x: number; y: number } | null,
     image: HTMLImageElement | null,
-    zoom: number,
   ) => {
     if (point && image) {
-      const markerSize = zoom * 2;
+      const markerSize = 32;
       ctx.drawImage(image, point.x - markerSize / 2, point.y - markerSize, markerSize, markerSize);
     }
   };
@@ -97,6 +96,20 @@ export const useRedrawCanvas = ({
     }
   };
 
+  // const getMarkerColor = (token: string): string => {
+  //   // 문자열 해싱을 통해 고유 숫자 생성
+  //   let hash = 0;
+  //   for (let i = 0; i < token.length; i++) {
+  //     hash = token.charCodeAt(i) + ((hash << 5) - hash);
+  //   }
+  //   // 해시 값을 기반으로 RGB 값 생성
+  //   const r = (hash >> 16) & 0xff;
+  //   const g = (hash >> 8) & 0xff;
+  //   const b = hash & 0xff;
+  //   // RGB를 HEX 코드로 변환
+  //   return `rgb(${r}, ${g}, ${b})`;
+  // };
+
   const redrawCanvas = () => {
     if (!canvasRef.current || !map) return;
 
@@ -110,15 +123,14 @@ export const useRedrawCanvas = ({
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
 
-    const zoom = map.getZoom();
     if (startMarker) {
       const startPoint = latLngToCanvasPoint(startMarker);
-      drawMarker(ctx, startPoint, startImageRef.current, zoom);
+      drawMarker(ctx, startPoint, startImageRef.current);
     }
 
     if (endMarker) {
       const endPoint = latLngToCanvasPoint(endMarker);
-      drawMarker(ctx, endPoint, endImageRef.current, zoom);
+      drawMarker(ctx, endPoint, endImageRef.current);
     }
 
     if (pathPoints) {
@@ -127,23 +139,24 @@ export const useRedrawCanvas = ({
 
     if (lat && lng) {
       const currentLocation = latLngToCanvasPoint({ lat, lng });
-      drawMarker(ctx, currentLocation, mylocationRef.current, zoom);
+      drawMarker(ctx, currentLocation, mylocationRef.current);
     }
 
     if (otherLocations) {
       otherLocations.forEach(({ location }) => {
+        // const markerColor = getMarkerColor(token);
         const locationPoint = latLngToCanvasPoint(location);
-        drawMarker(ctx, locationPoint, guestlocationmarkerRef.current, zoom);
+        drawMarker(ctx, locationPoint, guestlocationmarkerRef.current);
       });
     }
 
     if (guests) {
       guests.forEach(({ startPoint, endPoint, paths }) => {
         const startLocation = latLngToCanvasPoint(startPoint);
-        drawMarker(ctx, startLocation, startImageRef.current, zoom);
+        drawMarker(ctx, startLocation, startImageRef.current);
 
         const endLocation = latLngToCanvasPoint(endPoint);
-        drawMarker(ctx, endLocation, endImageRef.current, zoom);
+        drawMarker(ctx, endLocation, endImageRef.current);
 
         drawPath(ctx, paths);
       });

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -25,7 +25,7 @@ export const Main = () => {
   } = useContext(FooterContext);
   const { lat, lng, error } = getUserLocation();
   const [otherLocations, setOtherLocations] = useState<any[]>([]);
-  const MIN_HEIGHT = 0.36;
+  const MIN_HEIGHT = 0.15;
   const MAX_HEIGHT = 0.9;
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const [showLoginModal, setShowLoginModal] = useState<boolean>(false);

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useContext, useEffect, useState } from 'react';
-import { MdFormatListBulleted, MdLogout } from 'react-icons/md';
+import { MdLogout } from 'react-icons/md';
 import { FooterContext } from '@/component/layout/footer/LayoutFooterProvider';
 import { useNavigate } from 'react-router-dom';
 import { buttonActiveType } from '@/component/layout/enumTypes';
@@ -117,12 +117,14 @@ export const Main = () => {
   return (
     <div className="flex flex-col overflow-hidden">
       <header className="absolute left-0 right-0 top-0 z-10 flex p-4">
-        <button type="button" className="text-gray-700">
-          <MdFormatListBulleted size={24} />
-        </button>
         {isUserLoggedIn && (
-          <button type="button" className="ml-auto text-gray-700" onClick={handleLogout}>
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="flex flex-col items-center gap-2 text-gray-700"
+          >
             <MdLogout size={24} />
+            <span className="text-xs">로그아웃</span>
           </button>
         )}
       </header>

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -169,7 +169,7 @@ export const Main = () => {
       ) : (
         <BottomSheet minHeight={MIN_HEIGHT} maxHeight={MAX_HEIGHT} backgroundColor="#F1F1F1F2">
           <div className="h-full w-full cursor-pointer" onClick={handleLoginRequest}>
-            <div className="absolute left-1/2 top-[35%] flex -translate-x-1/2 transform cursor-pointer flex-col p-6 text-center">
+            <div className="absolute left-1/2 top-[20%] flex -translate-x-1/2 transform cursor-pointer flex-col p-6 text-center">
               <p className="text-grayscale-175 mb-5 text-lg font-normal">로그인을 진행하여</p>
               <p className="text-grayscale-175 mb-5 text-lg font-normal">더 많은 기능을</p>
               <p className="text-grayscale-175 text-lg font-normal">사용해보세요</p>

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -165,6 +165,7 @@ export const Main = () => {
               <hr className="my-2" />
             </Fragment>
           ))}
+          <div className="h-20" />
         </BottomSheet>
       ) : (
         <BottomSheet minHeight={MIN_HEIGHT} maxHeight={MAX_HEIGHT} backgroundColor="#F1F1F1F2">


### PR DESCRIPTION

## 📝 PR 개요

- 로그인
  - 왼쪽 상단 햄버거 버튼 대신 로그아웃 버튼으로 구현
  - 로그아웃 버튼에 로그아웃이라고 텍스트 넣기

- 지도
  - 지도 확대 축소 슬라이드바 줌 지도 사용하는 모든 곳에 넣기
  - 아이콘 이미지 키우기

- 바텀시트 
  - 바텀시트 맨 아래 컨탠츠가 버튼에 가려지는 문제 해결
  - 바텀시트 최초 높이 변경 및 로그인 유도 텍스트 위로 올리기
  - 바텀시트내에 컨텐츠 클릭 범위 전체로 변경


## ✅ 체크리스트 (Checklist)

- [x] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [x] 테스트가 통과하는지 확인
- [x] 스타일 가이드와 일관성을 유지했는지 확인
- [x] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [x] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인


## 🔄 관련 이슈 (Linked Issues)

#14 

## 📷 스크린샷 및 동영상 

https://github.com/user-attachments/assets/d3b22817-e4c3-45be-a717-a1de111368ed



