### PR TITLE
[FE][Fix] #394 : hostview의 게스트 이미지 아래 네온에 테두리 칠해져있는 문제 해결

### DIFF
--- a/frontend/src/hooks/useRedraw.ts
+++ b/frontend/src/hooks/useRedraw.ts
@@ -198,6 +198,7 @@ export const useRedrawCanvas = ({
     ctx.beginPath();
     ctx.arc(point.x, point.y + zoom + 1, radius, 0, 2 * Math.PI);
     ctx.fillStyle = gradient;
+    ctx.strokeStyle = 'transparent';
     ctx.fill();
 
     ctx.save();


### PR DESCRIPTION


## 📝 PR 개요

- hostview의 게스트 이미지 아래 네온에 테두리 칠해져있는 문제 해결

---

## 🔍 변경 사항

- hostview의 게스트 이미지 아래 네온에 테두리 칠해져있는 문제 해결

---

## ✅ 체크리스트 (Checklist)

- [X] 코드가 빌드 오류 없이 잘 작동하는지 확인
- [X] 테스트가 통과하는지 확인
- [X] 스타일 가이드와 일관성을 유지했는지 확인
- [X] 관련 문서가 업데이트되었는지 확인 (선택 사항)
- [X] 리뷰어가 이해할 수 있도록 주석이나 설명을 추가했는지 확인


---

## 🔄 관련 이슈 (Linked Issues)

#394

---

## 📷 스크린샷 및 동영상 (선택 사항)


- 기존 문제 화면

![image](https://github.com/user-attachments/assets/2812e9a8-eb07-4409-b0c0-4e1cbdb88d00)

- 해결 후 화면

![image](https://github.com/user-attachments/assets/f9234b0b-6449-4ea5-b5be-4204b52e6701)
